### PR TITLE
Added command for extracting Kickstart 1.2

### DIFF
--- a/extractWings.bat
+++ b/extractWings.bat
@@ -1,6 +1,7 @@
 SET "mypath=%~dp0"
 SET "mydir=%mypath:~0,-1%"
 7z e -tzip -aos -o"%mypath:~0,-1%" %* romwings.bin -r
+7z e -tzip -aos -o"%mypath:~0,-1%" %* Kick12.rom -r
 cd "%mydir%"
 ".\dd.exe" "if=%mydir%\romwings.bin" "of=%mydir%\wings-1.adf" bs=1 skip=4 count=901120
 ".\dd.exe" "if=%mydir%\romwings.bin" "of=%mydir%\wings-2.adf" bs=1 skip=901124 count=901120


### PR DESCRIPTION
With this change, you can now extract the Kickstart 1.2 firmware with the Windows script. The firmware file can be used in emulators if you don't have access to newer firmwares or if you're playing a game that can only run in this specific firmware.